### PR TITLE
feat: add register routes plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "@types/helmet": "0.0.45",
     "@types/jest": "24.0.23",
     "@types/jsonwebtoken": "8.3.5",
-    "@types/next": "9.0.0",
     "@types/node": "12.12.14",
     "@types/react": "16.9.13",
     "@types/react-dom": "16.9.4",

--- a/server/index.ts
+++ b/server/index.ts
@@ -24,6 +24,7 @@ import {
   resolverLogger,
 } from '@server/middleware';
 import config from '@config';
+import { registerRoutes } from './plugins/register-routes';
 
 const isDev = process.env.NODE_ENV !== 'production';
 const dbConnectionName = isDev ? 'development' : 'production';
@@ -121,6 +122,9 @@ app
       csrf({ cookie: { key: 'ds_csrf' } })(req, res, next);
     });
 
+    // Register plugins
+    await registerRoutes(server, app, routes);
+
     // Apply Express middleware to GraphQL server
     apollo.applyMiddleware({
       app: server,
@@ -131,23 +135,6 @@ app
         optionsSuccessStatus: 200,
       },
       bodyParserConfig: true,
-    });
-
-    routes.forEach(function defineRoutes(obj) {
-      const { route, page = null, middleware = [], controller = null } = obj;
-
-      if (!page) {
-        server.get(route, middleware, controller);
-      }
-
-      server.get(route, (req, res) =>
-        app.render(
-          req,
-          res,
-          `/${page}`,
-          Object.assign({}, req.query, req.params)
-        )
-      );
     });
 
     // Health & graceful shutdown

--- a/server/plugins/register-routes/index.ts
+++ b/server/plugins/register-routes/index.ts
@@ -1,0 +1,127 @@
+import express, { Express, Request, Response, Router } from 'express';
+import logger from '@server/modules/logger';
+import { Route, Middleware, Action } from './typings';
+
+interface ExpressRouter extends Router {
+  [key: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+}
+
+/**
+ * Registers a set of application routes against an Express.js HTTP server instance
+ *
+ * @param expressApp - An Express.js HTTP server instance
+ * @param nextApp - A Next.js app instance
+ * @param routes - An array of route objects
+ * @returns An array of route objects
+ *
+ * ```ts
+ * import { registerRoutes } from './plugins/register-routes'
+ *
+ * await registerRoutes(expressApp, nextApp, routes)
+ * ```
+ */
+export const registerRoutes = (
+  expressApp: Express,
+  nextApp: any,
+  appRoutes: Route[] = []
+): Promise<any[]> =>
+  new Promise(resolve => {
+    const expressServer = expressApp;
+    const nextServer = nextApp;
+
+    appRoutes.forEach((route: Route) => {
+      const router: ExpressRouter = express.Router();
+      const { path = '', middleware = [], routes = [] } = route;
+
+      logger.info({ path }, 'REGISTER-ROUTES: Registering route path');
+
+      middleware.forEach((middlewareFunc: Middleware) => {
+        if (!middlewareFunc.name || !middlewareFunc.function) {
+          logger.error(
+            { middlewareFunc },
+            'REGISTER-ROUTES: Ensure that each middleware is an object with a `name` and `function` property.'
+          );
+
+          throw new Error('Invalid middleware format');
+        }
+
+        logger.info(
+          { middleware: middlewareFunc.name },
+          'REGISTER-ROUTES: Registering router-level middleware'
+        );
+
+        router.use((req, res, next) =>
+          !req.url.startsWith('/_next')
+            ? middlewareFunc.function(req, res, next)
+            : next()
+        );
+      });
+
+      routes.forEach((action: Action) => {
+        const {
+          path = '', // eslint-disable-line no-shadow
+          page = '',
+          method = '',
+          middleware = [], // eslint-disable-line no-shadow
+          controller = null,
+        } = action;
+
+        if (!page && (!path || !method || !controller)) {
+          logger.error(
+            { path, controller },
+            'REGISTER-ROUTES: Ensure that each route has a `path` and `controller` property.'
+          );
+
+          throw new Error('Invalid route format');
+        }
+
+        if (page && !path) {
+          logger.error(
+            { path, page },
+            'REGISTER-ROUTES: Ensure a Next.js page has a `path`.'
+          );
+
+          throw new Error('Invalid Next.js route format');
+        }
+
+        if (page && (method || controller)) {
+          logger.error(
+            { path, page },
+            'REGISTER-ROUTES: Next.js pages should not have a `method` or `controller`.'
+          );
+
+          throw new Error('Invalid Next.js route format');
+        }
+
+        logger.info(
+          { path, method: method.toUpperCase() },
+          'REGISTER-ROUTES: Registering route action'
+        );
+
+        router[page ? 'get' : method](
+          path,
+          middleware.map((m: Middleware) => {
+            logger.info(
+              { middleware: m.name },
+              'REGISTER-ROUTES: Registering route action-level middleware'
+            );
+
+            return m.function;
+          }),
+          page
+            ? (req: Request, res: Response) =>
+                nextServer.render(
+                  req,
+                  res,
+                  page,
+                  Object.assign({}, req.query, req.params)
+                )
+            : controller
+        );
+      });
+
+      expressServer.use(path, router);
+    });
+
+    resolve(appRoutes);
+  });

--- a/server/plugins/register-routes/typings/index.ts
+++ b/server/plugins/register-routes/typings/index.ts
@@ -1,0 +1,20 @@
+import { Request, Response, NextFunction, Express } from 'express';
+
+export interface Route {
+  path: string | string[] | RegExp | RegExp[];
+  middleware?: Middleware[];
+  routes: Action[];
+}
+
+export interface Middleware {
+  name: string;
+  function: (req: Request, res: Response, next: NextFunction) => void;
+}
+
+export interface Action {
+  path: string;
+  page?: string;
+  method?: string;
+  middleware?: Middleware[];
+  controller?: (req: Request, res: Response, next: NextFunction) => void;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1764,13 +1764,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/next@9.0.0":
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/@types/next/-/next-9.0.0.tgz#29aca06f8a5cfffc974a83b87e52ca57b2a506c4"
-  integrity sha512-gnBXM8rP1mnCgT1uE2z8SnpFTKRWReJlhbZLZkOLq/CH1ifvTNwjIVtXvsywTy1dwVklf+y/MB0Eh6FOa94yrg==
-  dependencies:
-    next "*"
-
 "@types/node@*", "@types/node@12.12.14", "@types/node@>=6", "@types/node@^12.0.2":
   version "12.12.14"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.14.tgz#1c1d6e3c75dba466e0326948d56e8bd72a1903d2"
@@ -9475,7 +9468,7 @@ neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
-next@*, next@^9.1.4:
+next@^9.1.4:
   version "9.1.4"
   resolved "https://registry.yarnpkg.com/next/-/next-9.1.4.tgz#32991dd6b49adca4bac302828eb5a1b3654591b6"
   integrity sha512-NJA6bBdqEWLDksQEylUQ/R2PO0fXb63pOldEvkqggbhcB8j7TGe/UnyZeC0kipatez8h52emJEfoeYPdnTxxVQ==


### PR DESCRIPTION
- Allows registering of express.js routes and next.js routes via a format in a route.ts file